### PR TITLE
Store parameters and respective priors in dicts

### DIFF
--- a/bayesian_hmm/chain.py
+++ b/bayesian_hmm/chain.py
@@ -45,7 +45,7 @@ class Chain(object):
     @initialised_flag.setter
     def initialised_flag(self, value):
         if value is True:
-            raise AssertionError(
+            raise RuntimeError(
                 "Chain must be initialised through initialise_chain method"
             )
         elif value is False:
@@ -54,11 +54,11 @@ class Chain(object):
             raise ValueError("initialised flag must be Boolean")
 
     def __repr__(self):
-        return "<Chain size {0}>".format(len(self.emission_sequence))
+        return "<bayesian_hmm.Chain, size {0}>".format(self.T)
 
     def __str__(self, print_len=15):
         print_len = min(print_len - 1, self.T - 1)
-        return "Chain size={T}, seq={s}".format(
+        return "bayesian_hmm.Chain, size={T}, seq={s}".format(
             T=self.T,
             s=[
                 "{s}:{e}".format(s=s, e=e)
@@ -70,7 +70,7 @@ class Chain(object):
     def tabulate(self):
         """
         Convert the latent and emission sequences into a single numpy array.
-        :return: numpy array with dimension (l, 2), where l is the length of the Chain
+        :return: numpy array with shape (l, 2), where l is the length of the Chain
         """
         return np.column_stack(
             (copy.copy(self.latent_sequence), copy.copy(self.emission_sequence))
@@ -80,7 +80,7 @@ class Chain(object):
     def initialise(self, states):
         """
         Initialise the chain by sampling latent states.
-        Typically called directly from a HDPHMM object.
+        Typically called directly from an HDPHMM object.
         :param states: set of states to sample from
         :return: None
         """
@@ -103,7 +103,7 @@ class Chain(object):
         if self.T == 0:
             return 0
 
-        # get probability state & emission, at start and remaining time steps
+        # get probability of transition & of emission, at start and remaining time steps
         # np.prod([])==1, so this is safe
         p_initial = np.log(p_initial[self.latent_sequence[0]]) + np.log(
             p_emission[self.latent_sequence[0]][self.emission_sequence[0]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 scipy
 numpy
-pandas
 terminaltables
 tqdm
 sympy

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="bayesian_hmm",
-    version="0.0.1",
+    version="0.0.2",
     license="MIT",
     packages=setuptools.find_packages(exclude=["tests"]),
     author="James Ross",
@@ -16,7 +16,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=["scipy", "numpy", "pandas", "terminaltables", "tqdm", "sympy"],
+    install_requires=["scipy", "numpy", "terminaltables", "tqdm", "sympy"],
     test_suite="py.test",
     tests_require=["pytest", "black"],
 )

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -14,15 +14,65 @@ def test_mcmc():
     # estimate parameters, making use of multithreading functionality
     results = hmm.mcmc(n=100, burn_in=20)
 
+    # specify expected dict keys at nested levels
+    expected_results_keys = [
+        "state_count",
+        "chain_neglogp",
+        "hyperparameters",
+        "beta_emission",
+        "beta_transition",
+        "parameters",
+    ]
+    expected_hyperparameters_keys = [
+        "alpha",
+        "gamma",
+        "alpha_emission",
+        "gamma_emission",
+        "kappa",
+    ]
+
     # check that results contains expected elements
     assert len(results) == 6
-    assert all(len(r) == 8 for r in results)
-    assert all(type(r) == list for r in results)
-    assert all(len(x) == 5 for x in results[2])
+    assert list(results.keys()) == expected_results_keys
+    assert all(len(r) == 8 for r in results.values())
+    assert all(type(r) == list for r in results.values())
 
-    # check that elements have expected types
-    observed_types = list(map(lambda r: type(r[0]), results))
-    expected_types = [int, numpy.float64, tuple, dict, dict, tuple]
-    assert observed_types == expected_types
-    assert all(type(x) == float for hyperparams in results[2] for x in hyperparams)
-    assert all(x >= 0 for hyperparams in results[2] for x in hyperparams)
+    # state count and neglogp are straightforward sequences
+    assert all(type(x) == int for x in results["state_count"])
+    assert all(type(x) == numpy.float64 for x in results["chain_neglogp"])
+
+    # hyperparameters is a list of dicts with atmoic values
+    assert all(type(x) == dict for x in results["hyperparameters"])
+    assert all(
+        list(x.keys()) == expected_hyperparameters_keys
+        for x in results["hyperparameters"]
+    )
+    assert all(
+        type(y) in (float, int) for x in results["hyperparameters"] for y in x.values()
+    )
+    assert all(y >= 0 for x in results["hyperparameters"] for y in x.values())
+
+    # beta_emission and beta transition are dicts of floats
+    assert all(type(x) == dict for x in results["beta_emission"])
+    assert all(type(y) == float for x in results["beta_emission"] for y in x.values())
+    assert all(type(x) == dict for x in results["beta_transition"])
+    assert all(type(y) == float for x in results["beta_transition"] for y in x.values())
+
+    # parameters is a list of dicts, with each dict a point-in-time snap of parameters
+    assert all(type(x) == dict for x in results["parameters"])
+    assert all(type(y) == dict for x in results["parameters"] for y in x.values())
+    assert all(
+        type(y) == str or y is None
+        for x in results["parameters"]
+        for y in x["p_initial"]
+    )
+    assert all(
+        type(y) == dict
+        for x in results["parameters"]
+        for y in x["p_transition"].values()
+    )
+    assert all(
+        type(y) == dict for x in results["parameters"] for y in x["p_emission"].values()
+    )
+
+    # TODO: check that internal structure of p_* histories is consistent


### PR DESCRIPTION
Tidy codebase by using dicts in place of tuples
in multiple points throughout code. Makes resampling
much more readable, and code more consistent. Also,
expand testing to accomodate changes.