### PR TITLE
Specify master branch in badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bayesian Hidden Markov Models
 
-[![Build Status](https://img.shields.io/travis/jamesross2/Bayesian-HMM?logo=travis&style=flat-square)](https://travis-ci.org/jamesross2/Bayesian-HMM?style=flat-square)
+[![Build Status](https://img.shields.io/travis/jamesross2/Bayesian-HMM/master?logo=travis&style=flat-square)](https://travis-ci.org/jamesross2/Bayesian-HMM?style=flat-square)
+[![PyPI Version](https://img.shields.io/pypi/v/bayesian-hmm?label=PyPI&logo=pypi&style=flat-square)](https://pypi.org/project/bayesian-hmm/)
 
 This code implements a non-parametric Bayesian Hidden Markov model,
 sometimes referred to as a Hierarchical Dirichlet Process Hidden Markov

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="bayesian_hmm",
-    version="0.0.3",
+    version="0.0.4",
     license="MIT",
     packages=setuptools.find_packages(exclude=["tests"]),
     author="James Ross",


### PR DESCRIPTION
This will fix a bug where the README contains
an incorrect 'failing' badge, caused by another
branch.